### PR TITLE
Improve conflict resolver safety

### DIFF
--- a/src/stack/manager.rs
+++ b/src/stack/manager.rs
@@ -1107,7 +1107,10 @@ impl StackManager {
                                 .auto_resolve_conflicts(&conflicts)
                                 .await?
                             {
-                                self.conflict_resolver.verify_conflicts_resolved().await?;
+                                self
+                                    .conflict_resolver
+                                    .verify_conflicts_resolved(&conflicts)
+                                    .await?;
                                 print_success(
                                     "Automatically resolved conflicts and completed operation",
                                 );


### PR DESCRIPTION
## Summary
- clean stale state with git abort commands instead of deleting files
- avoid removing ORIG_HEAD
- stage only conflicted files when continuing
- adjust manager to new resolver API
- add regression tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685743d6c9e0832b80e34e38b0ef90c9