### PR TITLE
Implement stale git state handling

### DIFF
--- a/src/stack/manager.rs
+++ b/src/stack/manager.rs
@@ -1078,6 +1078,10 @@ impl StackManager {
 
         match git_state {
             GitState::Clean => Ok(()),
+            GitState::StaleRebase | GitState::StaleMerge | GitState::StaleCherryPick => {
+                self.conflict_resolver.cleanup_stale_state(git_state.clone())?;
+                Ok(())
+            }
             GitState::Rebasing | GitState::Merging | GitState::CherryPicking => {
                 print_warning(&format!(
                     "Git is in state {:?}. Recovery options:",


### PR DESCRIPTION
## Summary
- add new git stale state variants
- detect stale rebase/merge/cherry-pick without side effects
- provide cleanup helper and integrate with stack manager
- test clean and stale state handling

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685743b2b4b4832bb7916a93cf9a7e5f